### PR TITLE
downgrade aws-xray-recorder-sdk-core to v2.8.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :java-source-paths ["src/java"]
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [camel-snake-kebab "0.4.2"]
-                 [com.amazonaws/aws-xray-recorder-sdk-core "2.10.0"]
+                 [com.amazonaws/aws-xray-recorder-sdk-core "2.8.0"]
                  [funcool/promesa "6.0.2"]]
   :plugins [[lein-cloverage "1.2.2"]]
   :repl-options {:init-ns aws-xray-sdk-clj.core}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.hden/aws-xray-sdk-clj "0.3.2-SNAPSHOT"
+(defproject com.github.hden/aws-xray-sdk-clj "0.4.0-SNAPSHOT"
   :description "A light wrapper for aws-xray-sdk-java"
   :url "https://github.com/hden/aws-xray-sdk-clj"
   :license {:name "Apache License, Version 2.0"

--- a/test/aws_xray_sdk_clj/promise_test.clj
+++ b/test/aws_xray_sdk_clj/promise_test.clj
@@ -83,5 +83,5 @@
 (deftest random-subsegment-test
   @(with-segment [segment (core/begin! recorder {:trace-id (util/trace-id recorder)
                                                  :name     "baz"})]
-     (promesa/all (random-subsegments segment 20)))
+     (promesa/all (random-subsegments segment 50)))
   (is (<= 1 (count @segments))))


### PR DESCRIPTION
Downgrade aws-xray-recorder-sdk-core to v2.8.0 due to deadlock issues.

Ref:
https://github.com/aws/aws-xray-sdk-java/issues/303