### PR TITLE
fix macro

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.hden/aws-xray-sdk-clj "0.5.0-SNAPSHOT"
+(defproject com.github.hden/aws-xray-sdk-clj "0.5.1-SNAPSHOT"
   :description "A light wrapper for aws-xray-sdk-java"
   :url "https://github.com/hden/aws-xray-sdk-clj"
   :license {:name "Apache License, Version 2.0"

--- a/src/aws_xray_sdk_clj/promise.clj
+++ b/src/aws_xray_sdk_clj/promise.clj
@@ -16,5 +16,5 @@
   name."
   [bindings & body]
   `(let ~(subvec bindings 0 2)
-     (promesa/finally ~@body
+     (promesa/finally (do ~@body)
                       (handler ~(bindings 0)))))


### PR DESCRIPTION
Wrap macro body in a implicit do to prevent the following pattern

**code**

```clj
(with-segment [segment (core/start! recorder {:trace-id (util/trace-id recorder)
                                              :name     "foo"})]
   (core/set-annotation! segment {"foo" "bar"})
   (promesa/delay 10 "foobar"))
```

**error**

```
java.lang.ClassCastException: class aws_xray_sdk_clj.promise$handler$fn__2201 cannot be cast to class java.util.concurrent.Executor (aws_xray_sdk_clj.promise$handler$fn__2201 is in unnamed module of loader clojure.lang.DynamicClassLoader @40df6090; java.util.concurrent.Executor is in module java.base of loader 'bootstrap')
```