### PR TITLE
in-memory DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ A light wrapper for aws-xray-sdk-java.
 
 > High mutability and circular refrences between segments and subsegments create a prime landscape for thread issues. -- https://github.com/aws/aws-xray-sdk-java/pull/306#issue-1011630726
 
-This library tries to mitigate the problems by making sure that the thread local
-context is set before any operations.
+This library tries to mitigate the problems by...
+
+1. Replacing mutability and locks with a clojure atom
+2. Replacing circular refrences (between Java objects) with a in-memory DB ([datascript](https://github.com/tonsky/datascript))
+3. Recursively walk the tree and send the entities (a root segment and its subsegments) to Xray.
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.hden/aws-xray-sdk-clj "0.6.0"
+(defproject com.github.hden/aws-xray-sdk-clj "0.7.0"
   :description "A light wrapper for aws-xray-sdk-java"
   :url "https://github.com/hden/aws-xray-sdk-clj"
   :license {:name "Apache License, Version 2.0"
@@ -7,6 +7,7 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [camel-snake-kebab "0.4.3"]
                  [com.amazonaws/aws-xray-recorder-sdk-core "2.8.0"]
+                 [datascript "1.3.15"]
                  [funcool/promesa "8.0.450"]]
   :plugins [[lein-cloverage "1.2.4"]]
   :repl-options {:init-ns aws-xray-sdk-clj.core}

--- a/src/aws_xray_sdk_clj/core.clj
+++ b/src/aws_xray_sdk_clj/core.clj
@@ -10,14 +10,16 @@
   [arg-map]
   (impl/recorder arg-map))
 
-(defn ^String root-trace-id
+(defn root-trace-id
   "Get the root trace ID from a HTTP Header string."
+  ^String
   [^String s]
   (when s
     (protocol/-root-trace-id s)))
 
-(defn ^String parent-id
+(defn parent-id
   "Get the parent ID from a HTTP Header string."
+  ^String
   [^String s]
   (when s
     (protocol/-parent-id s)))

--- a/src/aws_xray_sdk_clj/impl.clj
+++ b/src/aws_xray_sdk_clj/impl.clj
@@ -1,24 +1,29 @@
 (ns aws-xray-sdk-clj.impl
   (:require [aws-xray-sdk-clj.protocols :as protocol]
-            [camel-snake-kebab.core :as csk])
+            [camel-snake-kebab.core :as csk]
+            [datascript.core :as d])
   (:import [com.amazonaws.xray AWSXRay AWSXRayRecorder AWSXRayRecorderBuilder]
            [com.amazonaws.xray.emitters Emitter]
-           [com.amazonaws.xray.entities Entity Subsegment TraceID TraceHeader]
+           [com.amazonaws.xray.entities Entity Subsegment TraceID TraceHeader Segment]
            [com.amazonaws.xray.plugins Plugin]
-           [com.amazonaws.xray.strategy.sampling SamplingStrategy]))
+           [com.amazonaws.xray.strategy.sampling SamplingStrategy]
+           [java.time Clock]))
 
 (def ^AWSXRayRecorder global-recorder (AWSXRay/getGlobalRecorder))
+(def ^Clock default-clock (Clock/systemUTC))
 
-(defn- ^AWSXRayRecorderBuilder apply-plugins! [^AWSXRayRecorderBuilder builder plugins]
+(defn- apply-plugins!
+  ^AWSXRayRecorderBuilder
+  [^AWSXRayRecorderBuilder builder plugins]
   (doseq [^Plugin plugin plugins]
     (.withPlugin builder plugin))
   builder)
 
-(defn ^AWSXRayRecorder recorder
+(defn recorder
   "Create an AWSXRayRecorder with options.
   Useful when you don't want to use the global recorder."
-  ([] (recorder {}))
-  ([{:keys [^Emitter emitter plugins ^SamplingStrategy sampling-strategy]}]
+  (^AWSXRayRecorder [] (recorder {}))
+  (^AWSXRayRecorder [{:keys [^Emitter emitter plugins ^SamplingStrategy sampling-strategy]}]
    (cond-> (AWSXRayRecorderBuilder/standard)
      emitter           (.withEmitter emitter)
      (seq plugins)     (apply-plugins! plugins)
@@ -32,78 +37,127 @@
        (when-let* ~(drop 2 bindings) ~@body))
     `(do ~@body)))
 
-(defrecord AEntity [^Entity entity]
+(def ^:private schema
+  {:subsegments {:db/cardinality :db.cardinality/many
+                 :db/valueType   :db.type/ref}})
+
+(defn ^:private sanitize-keys [m]
+  (into {}
+        (map (fn [[k v]]
+               [(csk/->snake_case_string k) v]))
+        m))
+
+(defn ^:private current-timestamp-seconds
+  [^Clock clock]
+  (double (/ (.millis clock) 1000)))
+
+(defn ^:private add-attributes!
+  ^Entity
+  [^Entity entity {:keys [db eid]}]
+  (let [{:keys [start-at end-at annotations exception metadata]}
+        (d/pull db '[*] eid)]
+    (when start-at
+      (.setStartTime entity start-at))
+    (when (map? annotations)
+      (doseq [[^String key v] annotations]
+        (cond
+          (boolean? v) (.putAnnotation entity key ^Boolean v)
+          (number? v)  (.putAnnotation entity key ^Number v)
+          :else        (.putAnnotation entity key (str v)))))
+    (when (map? metadata)
+      (doseq [[^String key v] metadata]
+        (.putMetadata entity key (str v))))
+    (when exception
+      (.addException entity exception)
+      (.setError entity true))
+    (when end-at
+      (.setEndTime entity end-at))
+    entity))
+
+(defn ^:private create-segment!
+  ^Segment
+  [^AWSXRayRecorder recorder {:as arg-map :keys [db]}]
+  (let [eid 1
+        {:keys [name trace-id parent-id]}
+        (d/pull db [:name :trace-id :parent-id] eid)
+        segment (if trace-id
+                  (.beginSegment recorder name (TraceID/fromString trace-id) parent-id)
+                  (.beginSegment recorder name))]
+    (add-attributes! segment (assoc arg-map :eid eid))
+    segment))
+
+(defn ^:private create-subsegment!
+  ^Subsegment
+  [^AWSXRayRecorder recorder {:as arg-map :keys [db eid]}]
+  (let [{:keys [name]} (d/pull db [:name] eid)
+        subsegment (.beginSubsegment recorder name)]
+    (add-attributes! subsegment arg-map)
+    subsegment))
+
+(defn ^:private send-trace! [{:as arg-map
+                              :keys [eid conn ^AWSXRayRecorder recorder]
+                              :or {eid 1}}]
+  (let [db @conn
+        tree (d/pull db
+                     '[[:db/id :as :eid]
+                       {:subsegments 1}]
+                     eid)]
+    (if (= eid 1)
+      (create-segment! recorder {:db db})
+      (create-subsegment! recorder {:db db :eid eid}))
+    (when-let [subsegments (seq (:subsegments tree))]
+      (doseq [{:keys [eid]} subsegments]
+        (send-trace! (assoc arg-map :eid eid))))
+    (if (= eid 1)
+      (.endSegment recorder)
+      (.endSubsegment recorder))))
+
+(defrecord AEntity [eid conn ^Clock clock ^AWSXRayRecorder recorder]
   ;; Implement AutoCloseable by default so that this can work with 'open-with'
   java.lang.AutoCloseable
-  (close [_]
+  (close [entity]
     (protocol/-close! entity))
 
   protocol/IAutoCloseable
-  (-close! [_]
-    (protocol/-close! entity))
+  (-close! [{:as entity :keys [eid conn]}]
+    (let [current-timestamp (current-timestamp-seconds clock)]
+      (d/transact! conn [{:db/id eid :end-at current-timestamp}]))
+    (when (= 1 eid)
+      (send-trace! entity))
+    nil)
 
   protocol/IEntity
-  (-set-exception! [this ex]
-    (when entity
-      (doto entity
-        (.addException ex)
-        (.setError true)))
-    this)
+  (-set-exception! [{:as entity :keys [eid conn]} ex]
+    (d/transact! conn [{:db/id eid :exception ex}])
+    entity)
 
-  (-set-annotation! [this m]
-    (when entity
-      (doseq [[k v] m]
-        (let [^String key (csk/->snake_case_string k)]
-          (cond
-            (boolean? v) (.putAnnotation entity key ^Boolean v)
-            (number? v)  (.putAnnotation entity key ^Number v)
-            :else        (.putAnnotation entity key (str v))))))
-    this)
+  (-set-annotation! [{:as entity :keys [eid conn]} m]
+    (let [annotations (sanitize-keys m)]
+      (d/transact! conn [{:db/id eid :annotations annotations}])
+      entity))
 
-  (-set-metadata! [this m]
-    (when entity
-      (doseq [[k v] m]
-        (.putMetadata entity (csk/->snake_case_string k) (str v))))
-    this))
+  (-set-metadata! [{:as entity :keys [eid conn]} m]
+    (let [metadata (sanitize-keys m)]
+      (d/transact! conn [{:db/id eid :metadata metadata}])
+      entity)))
 
 (extend-protocol protocol/IEntityProvider
   AWSXRayRecorder
-  (-start! [^AWSXRayRecorder recorder arg-map]
-    (let [^String name (get arg-map :name)
-          ^String trace-id (get arg-map :trace-id)
-          ^String parent-id (get arg-map :parent-id)]
-      (-> (if trace-id
-            (.beginSegment recorder name (TraceID/fromString trace-id) parent-id)
-            (.beginSegment recorder name))
-        (->AEntity))))
+  (-start! [^AWSXRayRecorder recorder {:as arg-map
+                                       :keys [clock]
+                                       :or {clock default-clock}}]
+    (let [conn (d/create-conn schema)
+          current-timestamp (current-timestamp-seconds clock)
+          segment (merge (select-keys arg-map [:name :trace-id :parent-id])
+                         {:db/id 1 :start-at current-timestamp})]
+      (d/transact! conn [segment])
+      (->AEntity 1 conn clock recorder)))
 
   AEntity
-  (-start! [{:keys [^Entity entity]} arg-map]
-    (let [^String name (get arg-map :name)
-          ^AWSXRayRecorder recorder (.getCreator entity)
-          result (atom nil)]
-      (.run entity #(reset! result (.beginSubsegment recorder name)))
-      (->AEntity @result)))
-
-  nil
-  (-start! [_ _]
-    (->AEntity (.beginNoOpSegment global-recorder))))
-
-(extend-protocol protocol/IAutoCloseable
-  Subsegment
-  (-close! [^Subsegment subsegment]
-    (let [^AWSXRayRecorder recorder (.getCreator subsegment)]
-      (.endSubsegment recorder subsegment)
-      nil))
-
-  Entity
-  (-close! [^Entity entity]
-    (.run entity #(.close entity))
-    nil)
-
-  nil
-  (-close! [_]
-    nil))
+  (-start! [{:keys [eid conn clock recorder]} {:keys [name]}]
+    (let [{:keys [tempids]} (d/transact! conn [{:db/id -1  :name  name}
+                                               {:db/id eid :subsegments [-1]}])]
+      (->AEntity (get tempids -1) conn clock recorder))))
 
 (extend-protocol protocol/ITraceHeader
   String

--- a/test/aws_xray_sdk_clj/promise_test.clj
+++ b/test/aws_xray_sdk_clj/promise_test.clj
@@ -1,4 +1,5 @@
 (ns aws-xray-sdk-clj.promise-test
+  (:refer-clojure :exclude [with-open])
   (:require [aws-xray-sdk-clj.core :as core]
             [aws-xray-sdk-clj.promise :refer [with-open]]
             [aws-xray-sdk-clj.test-util :as util]
@@ -8,13 +9,13 @@
             [promesa.exec :as exec]))
 
 (def segments (atom []))
-(def entity (atom {}))
+(def ^:const fixed-timestamp 1662905704)
 
 (def mock-emitter (util/mock-emitter segments))
+(def mock-clock (util/mock-clock fixed-timestamp))
 
 (defn reset-fixtures! [f]
   (reset! segments [])
-  (reset! entity {})
   (f))
 
 (use-fixtures :each reset-fixtures!)
@@ -23,61 +24,65 @@
 
 (deftest ex-handler-test
   (let [p (with-open [segment (core/start! recorder {:trace-id (util/trace-id recorder)
-                                                        :name     "foo"})]
+                                                     :clock    mock-clock
+                                                     :name     "foo"})]
             (promesa/future
               (core/set-annotation! segment {"foo" "bar"})
               (throw (ex-info "Oops" {"foo" "bar"}))))]
     (is (thrown-with-msg? java.util.concurrent.ExecutionException #"Oops" @p))
-    (is (= 1 (count @segments)))
-    (let [segment (first @segments)]
-      (is (:error segment)))))
+    (let [coll @segments]
+      (is (= 1 (count coll)))
+      (is (= "clojure.lang.ExceptionInfo: Oops {\"foo\" \"bar\"}"
+             (get-in @segments [0 :cause :exceptions 0 :message]))))))
 
 (deftest async-segment-test
   (let [p (with-open [segment (core/start! recorder {:trace-id (util/trace-id recorder)
-                                                        :name     "foo"})]
-            (core/set-annotation! segment {"foo" "bar"})
+                                                     :clock    mock-clock
+                                                     :name     "foo"})]
+            (core/set-annotation! segment {:foo "bar"})
             (promesa/delay 10 "foobar"))]
     (is (= "foobar" @p))
-    (let [segment (first @segments)]
-      (is (= "foo" (:name segment)))
-      (is (nil? (seq (:subsegments segment))))
-      (is (= "bar" (get-in segment [:annotations :foo]))))))
+    (let [coll @segments]
+      (is (= "foo" (get-in coll [0 :name])))
+      (is (nil? (seq (get-in coll [0 :subsegments]))))
+      (is (= {:foo "bar"} (get-in coll [0 :annotations]))))))
 
 (deftest async-subsegment-test
   (let [p (with-open [segment (core/start! recorder {:trace-id (util/trace-id recorder)
-                                                        :name     "bar"})]
+                                                     :clock    mock-clock
+                                                     :name     "bar"})]
             (-> (promesa/delay 10 "foobar")
-              (promesa/then (fn [_]
-                              (with-open [subsegment (core/start! segment {:name "baz"})]
-                                (core/set-annotation! subsegment {"foo" "bar"})
-                                (promesa/delay 10 "baz")))
-                            exec/default-executor)))]
+                (promesa/then (fn [_]
+                                (with-open [subsegment (core/start! segment {:name "baz"})]
+                                  (core/set-annotation! subsegment {:foo "bar"})
+                                  (promesa/delay 10 "baz")))
+                              exec/default-executor)))]
     (is (= "baz" @p))
-    (let [segment (first @segments)
-          subsegments (:subsegments segment)
-          subsegment (first subsegments)]
-      (is (= "bar" (:name segment)))
-      (is (= 1 (count subsegments)))
-      (is (= "bar" (get-in subsegment [:annotations :foo]))))))
+    (let [coll @segments]
+      (is (= "bar" (get-in coll [0 :name])))
+      (is (= 1 (count (get-in coll [0 :subsegments]))))
+      (is (= "baz" (get-in coll [0 :subsegments 0 :name])))
+      (is (= {:foo "bar"} (get-in coll [0 :subsegments 0 :annotations]))))))
 
 (defn random-subsegments [segment n]
   (map (fn [_]
          (-> (promesa/delay (rand-int 10) true)
-           (promesa/then (fn [_]
-                           (let [id (cuid)]
-                             (with-open [subsegment (core/start! segment {:name id})]
-                               (-> (promesa/delay (rand-int 10) true)
-                                 (promesa/then (fn [_]
-                                                 (core/set-annotation! subsegment {:id id})
-                                                 (promesa/all (random-subsegments subsegment (int (Math/floor (/ n 2))))))
-                                               exec/default-executor)))))
-                         exec/default-executor)))
+             (promesa/then (fn [_]
+                             (let [id (cuid)]
+                               (with-open [subsegment (core/start! segment {:name id})]
+                                 (-> (promesa/delay (rand-int 10) true)
+                                   (promesa/then (fn [_]
+                                                   (core/set-annotation! subsegment {:id id})
+                                                   (promesa/all (random-subsegments subsegment (int (Math/floor (/ n 2))))))
+                                                 exec/default-executor)))))
+                           exec/default-executor)))
        (range n)))
 
 ;; Ensure we don't stumble on a deadlock due to synchronized blocks.
 ;; https://github.com/aws/aws-xray-sdk-java/issues/303
 (deftest random-subsegment-test
   @(with-open [segment (core/start! recorder {:trace-id (util/trace-id recorder)
+                                              :clock    mock-clock
                                               :name     "baz"})]
      (promesa/all (random-subsegments segment 50)))
   (is (<= 1 (count @segments))))

--- a/test/aws_xray_sdk_clj/test_util.clj
+++ b/test/aws_xray_sdk_clj/test_util.clj
@@ -1,7 +1,8 @@
 (ns aws-xray-sdk-clj.test-util
   (:require [clojure.data.json :as json])
   (:import [com.amazonaws.xray.emitters Emitter]
-           [com.amazonaws.xray.entities Entity Subsegment TraceID]))
+           [com.amazonaws.xray.entities Entity Subsegment TraceID]
+           [java.time Clock Instant ZoneId]))
 
 (defprotocol Serializable
   (serialize [entity]))
@@ -31,3 +32,7 @@
 
 (defn trace-id [recorder]
   (.toString (TraceID/create recorder)))
+
+(defn mock-clock [x]
+  (Clock/fixed (Instant/ofEpochSecond x)
+               (ZoneId/of "UTC")))


### PR DESCRIPTION
Side-stepping the locks (and deadlocks) by...

1. Replacing mutability and locks with a clojure atom
2. Replacing circular refrences (between Java objects) with a in-memory DB ([datascript](https://github.com/tonsky/datascript))
3. Recursively walk the tree and send the entities (a root segment and its subsegments) to Xray.