### PR TITLE
Async / non-blocking event processor

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
                  [camel-snake-kebab "0.4.3"]
                  [com.amazonaws/aws-xray-recorder-sdk-core "2.13.0"]
                  [datascript "1.4.0"]
+                 [diehard "0.11.6"]
                  [funcool/promesa "9.0.489"]
                  [org.clojure/core.async "1.6.673"]]
   :plugins [[lein-cloverage "1.2.4"]]

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,8 @@
                  [camel-snake-kebab "0.4.3"]
                  [com.amazonaws/aws-xray-recorder-sdk-core "2.13.0"]
                  [datascript "1.4.0"]
-                 [funcool/promesa "9.0.489"]]
+                 [funcool/promesa "9.0.489"]
+                 [org.clojure/core.async "1.6.673"]]
   :plugins [[lein-cloverage "1.2.4"]]
   :repl-options {:init-ns aws-xray-sdk-clj.core}
   :global-vars {*warn-on-reflection* true}

--- a/test/aws_xray_sdk_clj/core_test.clj
+++ b/test/aws_xray_sdk_clj/core_test.clj
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [with-open])
   (:require [aws-xray-sdk-clj.core :as core]
             [aws-xray-sdk-clj.test-util :as util]
+            [clojure.core.async :as a :refer [<!!]]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.walk :refer [postwalk]]))
 
@@ -25,6 +26,7 @@
           ex (ex-info "test" {:foo "bar"})]
       (core/set-exception! segment ex)
       (core/close! segment)
+      (<!! (:done segment))
       (is (= "test" (get-in @segments [0 :cause :exceptions 0 :message]))))))
 
 (deftest set-annotation-test
@@ -35,6 +37,7 @@
                        :boolean true}]
       (core/set-annotation! segment annotations)
       (core/close! segment)
+      (<!! (:done segment))
       (is (= annotations (get-in @segments [0 :annotations]))))))
 
 (deftest set-metadata-test
@@ -43,6 +46,7 @@
           metadata {:foobar "baz"}]
       (core/set-metadata! segment metadata)
       (core/close! segment)
+      (<!! (:done segment))
       (is (= metadata (get-in @segments [0 :metadata :default]))))))
 
 (deftest trace-header-test
@@ -60,93 +64,108 @@
 
 (deftest with-open-close-test
   (testing "close"
-    (core/with-open [segment (core/start! recorder {:trace-id (util/trace-id recorder)
-                                                    :clock    mock-clock
-                                                    :name     "hoge"})]
-      (core/set-annotation! segment {"foo" "bar"}))
-    (is (= "hoge" (get-in @segments [0 :name])))))
+    (let [done (atom nil)]
+      (core/with-open [segment (core/start! recorder {:trace-id (util/trace-id recorder)
+                                                      :clock    mock-clock
+                                                      :name     "hoge"})]
+        (core/set-annotation! segment {"foo" "bar"})
+        (reset! done (:done segment)))
+      (<!! @done)
+      (is (= "hoge" (get-in @segments [0 :name]))))))
 
 (deftest with-open-exception-handler-test
   (testing "exception handler"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Oops"
-          (core/with-open [segment (core/start! recorder {:trace-id (util/trace-id recorder)
-                                                          :clock    mock-clock
-                                                          :name     "hoge"})]
-            (core/set-annotation! segment {"foo" "bar"})
-            (throw (ex-info "Oops" {})))))
-    (is (= 1 (count @segments)))
-    (is (= "Oops" (get-in @segments [0 :cause :exceptions 0 :message])))))
+    (let [done (atom nil)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Oops"
+            (core/with-open [segment (core/start! recorder {:trace-id (util/trace-id recorder)
+                                                            :clock    mock-clock
+                                                            :name     "hoge"})]
+              (core/set-annotation! segment {"foo" "bar"})
+              (reset! done (:done segment))
+              (throw (ex-info "Oops" {})))))
+      (<!! @done)
+      (is (= 1 (count @segments)))
+      (is (= "Oops" (get-in @segments [0 :cause :exceptions 0 :message]))))))
 
 (deftest segment-test
   (testing "begin-segment!"
-    (core/with-open [segment (core/start! recorder {:trace-id (util/trace-id recorder)
-                                                    :clock    mock-clock
-                                                    :name     "foo"})]
-      (core/set-annotation! segment {"foo" "bar"}))
-    (let [coll @segments]
-      (is (= 1 (count coll)))
-      (is (= "foo" (get-in coll [0 :name])))
-      (is (= (double fixed-timestamp) (get-in coll [0 :start_time])))
-      (is (= (double fixed-timestamp) (get-in coll [0 :end_time])))
-      (is (nil? (seq (get-in coll [0 :subsegments]))))
-      (is (= {:foo "bar"} (get-in coll [0 :annotations]))))))
+    (let [done (atom nil)]
+      (core/with-open [segment (core/start! recorder {:trace-id (util/trace-id recorder)
+                                                      :clock    mock-clock
+                                                      :name     "foo"})]
+        (core/set-annotation! segment {"foo" "bar"})
+        (reset! done (:done segment)))
+      (<!! @done)
+      (let [coll @segments]
+        (is (= 1 (count coll)))
+        (is (= "foo" (get-in coll [0 :name])))
+        (is (= (double fixed-timestamp) (get-in coll [0 :start_time])))
+        (is (= (double fixed-timestamp) (get-in coll [0 :end_time])))
+        (is (nil? (seq (get-in coll [0 :subsegments]))))
+        (is (= {:foo "bar"} (get-in coll [0 :annotations])))))))
 
 (deftest subsegment-test
   (testing "begin-subsegment!"
-    (core/with-open [segment (core/start! recorder {:trace-id (util/trace-id recorder)
-                                                    :clock    mock-clock
-                                                    :name     "foo"})]
-      (core/with-open [subsegment (core/start! segment {:name "bar"})]
-        (core/set-annotation! subsegment {:foo "bar"})))
-    (let [coll @segments]
-      (is (= 1 (count coll)))
-      (is (= "foo" (get-in coll [0 :name])))
-      (is (= "bar" (get-in coll [0 :subsegments 0 :name])))
-      (is (= {:foo "bar"} (get-in coll [0 :subsegments 0 :annotations]))))))
+    (let [done (atom nil)]
+      (core/with-open [segment (core/start! recorder {:trace-id (util/trace-id recorder)
+                                                      :clock    mock-clock
+                                                      :name     "foo"})]
+        (core/with-open [subsegment (core/start! segment {:name "bar"})]
+          (core/set-annotation! subsegment {:foo "bar"})
+          (reset! done (:done segment))))
+      (<!! @done)
+      (let [coll @segments]
+        (is (= 1 (count coll)))
+        (is (= "foo" (get-in coll [0 :name])))
+        (is (= "bar" (get-in coll [0 :subsegments 0 :name])))
+        (is (= {:foo "bar"} (get-in coll [0 :subsegments 0 :annotations])))))))
 
 (deftest big-tree-test
   (testing "begin-subsegment!"
-    (core/with-open [root (core/start! recorder {:trace-id (util/trace-id recorder)
-                                                    :clock    mock-clock
-                                                    :name     "root"})]
-      (core/with-open [a (core/start! root {:name "1"})]
-        (core/with-open [b (core/start! a {:name "1-1"})]
-          (core/set-annotation! b {:foo "bar"}))
-        (core/with-open [c (core/start! a {:name "1-2"})]
-          (core/with-open [d (core/start! c {:name "1-2-1"})]
-            (core/set-annotation! d {:foo "bar"})))
-        (core/with-open [d (core/start! a {:name "1-3"})]
-          (core/with-open [e (core/start! d {:name "1-3-1"})]
-            (core/set-annotation! e {:foo "bar"}))
-          (core/with-open [f (core/start! d {:name "1-3-2"})]
-            (core/set-annotation! f {:foo "bar"}))))
-      (core/with-open [g (core/start! root {:name "2"})]
-        (core/with-open [h (core/start! g {:name "2-1"})]
-          (core/with-open [i (core/start! h {:name "2-1-1"})]
-            (core/with-open [j (core/start! i {:name "2-1-1-1"})]
-              (core/set-annotation! j {:foo "bar"}))))))
-    (let [coll @segments]
-      (is (= [{:name "root"
-               :subsegments
-               [{:name "1"
+    (let [done (atom nil)]
+      (core/with-open [root (core/start! recorder {:trace-id (util/trace-id recorder)
+                                                      :clock    mock-clock
+                                                      :name     "root"})]
+        (reset! done (:done root))
+        (core/with-open [a (core/start! root {:name "1"})]
+          (core/with-open [b (core/start! a {:name "1-1"})]
+            (core/set-annotation! b {:foo "bar"}))
+          (core/with-open [c (core/start! a {:name "1-2"})]
+            (core/with-open [d (core/start! c {:name "1-2-1"})]
+              (core/set-annotation! d {:foo "bar"})))
+          (core/with-open [d (core/start! a {:name "1-3"})]
+            (core/with-open [e (core/start! d {:name "1-3-1"})]
+              (core/set-annotation! e {:foo "bar"}))
+            (core/with-open [f (core/start! d {:name "1-3-2"})]
+              (core/set-annotation! f {:foo "bar"}))))
+        (core/with-open [g (core/start! root {:name "2"})]
+          (core/with-open [h (core/start! g {:name "2-1"})]
+            (core/with-open [i (core/start! h {:name "2-1-1"})]
+              (core/with-open [j (core/start! i {:name "2-1-1-1"})]
+                (core/set-annotation! j {:foo "bar"}))))))
+      (<!! @done)
+      (let [coll @segments]
+        (is (= [{:name "root"
                  :subsegments
-                 [{:name "1-1"}
-                  {:name "1-2"
+                 [{:name "1"
                    :subsegments
-                   [{:name "1-2-1"}]}
-                  {:name "1-3"
-                   :subsegments
-                   [{:name "1-3-1"}
-                    {:name "1-3-2"}]}]}
-                {:name "2"
-                 :subsegments
-                 [{:name "2-1"
-                   :subsegments
-                   [{:name "2-1-1"
+                   [{:name "1-1"}
+                    {:name "1-2"
                      :subsegments
-                     [{:name "2-1-1-1"}]}]}]}]}]
-             (postwalk (fn [x]
-                         (if (map? x)
-                           (select-keys x [:name :subsegments])
-                           x))
-                       coll))))))
+                     [{:name "1-2-1"}]}
+                    {:name "1-3"
+                     :subsegments
+                     [{:name "1-3-1"}
+                      {:name "1-3-2"}]}]}
+                  {:name "2"
+                   :subsegments
+                   [{:name "2-1"
+                     :subsegments
+                     [{:name "2-1-1"
+                       :subsegments
+                       [{:name "2-1-1-1"}]}]}]}]}]
+               (postwalk (fn [x]
+                           (if (map? x)
+                             (select-keys x [:name :subsegments])
+                             x))
+                         coll)))))))


### PR DESCRIPTION
**WHY?**

I've received reports indicating that blocking operations such as send-trace significantly reduces application performance. This PR tries to remediate the problem in two ways:

1. Makes all operations asynchronous and handle events in a thread pool (core.async/go)
2. Prevent thread pool exhaustion by throttling send-trace

We may lose some data but the impact to the application performance should be significantly reduced.